### PR TITLE
Add Queue in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ Here’s how to add Laravel Queues to Plesk Laravel Toolkit:
 1. [Integrate the Queue Laravel package into Plesk](https://support.plesk.com/hc/en-us/articles/9574602107410)
 2. [Enable the Scheduled Tasks](https://docs.plesk.com/en-US/obsidian/administrator-guide/website-management/laravel-toolkit.80010/#viewing-your-application-s-scheduled-tasks).
 3. Enable Queues in Laravel Toolkit. To do so, go to ***Websites & Domains** > your domain > **Manage Laravel Application**, and then on the "Dashboard" tab, click the **Queues** toggle button so that it shows "Enabled".
+
+### Publish configuration file and set your Queues
+1. Publish file
+`$ php artisan vendor:publish --tag=plesk-ext-laravel-config`
+
+If you are using sail
+`$ sail artisan vendor:publish --tag=plesk-ext-laravel-config`
+
+2. Set queues in .env file. (orders,exports are just an example)
+`PLESK_EXT_LARAVEL_QUEUE_WORKER_LIST=default,orders,exports`

--- a/config/plesk-ext-laravel.php
+++ b/config/plesk-ext-laravel.php
@@ -12,6 +12,8 @@ return [
             'max-jobs' => env('PLESK_EXT_LARAVEL_QUEUE_WORKER_MAX_JOBS'),
             // The maximum number of seconds the worker should run. Default: 0 (unlimited)
             'max-time' => env('PLESK_EXT_LARAVEL_QUEUE_WORKER_MAX_TIME'),
+            // Set list of queues divided by comma to execute. Example: default,orders,exports
+            'queue' => env('PLESK_EXT_LARAVEL_QUEUE_WORKER_LIST', 'default')
         ],
     ],
 ];

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -22,6 +22,8 @@ class ConsoleServiceProvider extends ServiceProvider
     public function register()
     {
         $configSource = $this->ensureConfigSource();
+        /** Add publish method for configuration file */
+        $this->publishes([module_path(self::PLESK_EXT_LARAVEL_CONFIG_PATH, 'config/plesk-ext-laravel.php') => config_path('plesk-ext-laravel.php')], 'plesk-ext-laravel-config');
         $this->mergeConfigFrom(self::PLESK_EXT_LARAVEL_CONFIG_PATH, 'plesk-ext-laravel');
         config()->set('plesk-ext-laravel.config-source', $configSource);
 

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -23,7 +23,7 @@ class ConsoleServiceProvider extends ServiceProvider
     {
         $configSource = $this->ensureConfigSource();
         /** Add publish method for configuration file */
-        $this->publishes([module_path(self::PLESK_EXT_LARAVEL_CONFIG_PATH, 'config/plesk-ext-laravel.php') => config_path('plesk-ext-laravel.php')], 'plesk-ext-laravel-config');
+        $this->publishes([self::PLESK_EXT_LARAVEL_CONFIG_PATH => config_path('plesk-ext-laravel.php')], 'plesk-ext-laravel-config');
         $this->mergeConfigFrom(self::PLESK_EXT_LARAVEL_CONFIG_PATH, 'plesk-ext-laravel');
         config()->set('plesk-ext-laravel.config-source', $configSource);
 


### PR DESCRIPTION
Add `queue` key inside `queue-worker.params` with environment key `PLESK_EXT_LARAVEL_QUEUE_WORKER_LIST` so user will be able to set other queues instead of default.
Add a publish command to use a local configuration file and add other params.